### PR TITLE
Add flag to run cibuild and and test scripts locally in virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 
 .coverage
 coverage.xml
+
+env/

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -2,7 +2,8 @@
 
 set -e
 
-if [[ -n "${CI}" ]]; then
+if [[ -n "${CI}" ]]; 
+then
     set -x
 fi
 
@@ -13,14 +14,30 @@ Setup CI environment and execute tests.
 "
 }
 
-if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
-    if [ "${1:-}" = "--help" ]; then
-        usage
-    else
-        # Install/upgrade dependencies
-        python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
+function ci() {
+    # Install/upgrade dependencies
+    python -m pip install --upgrade pip
+    pip install -r requirements-dev.txt
 
-        ./scripts/test
+    ./scripts/test
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; 
+then
+    if [ "${1:-}" = "--help" ]; 
+    then
+        usage
+    # use '--local' flag to run in venv locally
+    elif [ "${1:-}" = "--local" ]; 
+    then
+        python3 -m pip install --user virtualenv
+        python3 -m venv env
+        source env/bin/activate
+        
+        ci
+        
+        deactivate
+    else
+        ci
     fi
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -1,9 +1,9 @@
-
 #!/bin/bash
 
 set -e
 
-if [[ -n "${CI}" ]]; then
+if [[ -n "${CI}" ]]; 
+then
     set -x
 fi
 
@@ -14,18 +14,34 @@ Execute project linters and test suites.
 "
 }
 
-if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
-    if [ "${1:-}" = "--help" ]; then
+function t() {
+    # Lint
+    flake8 pycurb tests
+
+    # Code formatting
+    yapf -dpr pycurb tests
+
+    # Test suite with coverage enabled
+    coverage run --source=pycurb/ -m unittest discover tests/
+    coverage xml
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; 
+then
+    if [ "${1:-}" = "--help" ]; 
+    then
         usage
+    # use '--local' flag to run in venv locally
+    elif [ "${1:-}" = "--local" ];
+    then
+        python3 -m pip install --user virtualenv
+        python3 -m venv env
+        source env/bin/activate
+        
+        t
+        
+        deactivate
     else
-        # Lint
-        flake8 pycurb tests
-
-        # Code formatting
-        yapf -dpr pycurb tests
-
-        # Test suite with coverage enabled
-        coverage run --source=pycurb/ -m unittest discover tests/
-        coverage xml
+        t
     fi
 fi


### PR DESCRIPTION
@CloudNiner thanks for that CI PR. I had one issue in which I was unable to run the tests locally do to [this problem](https://gitlab.com/pycqa/flake8/-/issues/406) (version compatability between flake8 and pycodestyle). This was the case even when I installed all of the development requirements via `pip install -r requirements-dev.txt`.

I would like to be able to run these scripts locally so I added a `--local` flag to both of those scripts to enable that. 

Do you think this makes sense?

## To Test

run `./scripts/cibuild --local` and `./scripts/test --local`